### PR TITLE
Add Throwable to dependencies (prevents installation)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,6 +14,7 @@ WriteMakefile(
                   'JSON'           => 0,
                   'String::Util'   => 0,
 		  'List::Util'     => "1.46",
+                  'Throwable'      => 0,
     },
     clean => {
         FILES => 'cover_db test-*',


### PR DESCRIPTION
Hi,

   Just looks like a missing dependency :smile: 

   Would you be interested in me converting the module to use Dist::Zilla? The way I know to convert it, you would win:
  - deps in a cpanfile (with separate runtime, development and testing dependencies): the Makefile.PL would be automatically generated)
  - installing jp.pl as part of the distribution
