### PR TITLE
Added an evaluate function that returns datastructures

### DIFF
--- a/lib/Jmespath.pm
+++ b/lib/Jmespath.pm
@@ -15,6 +15,11 @@ sub compile {
   return Jmespath::Parser->new->parse( Encode::encode_utf8($expression) );
 }
 
+sub evaluate {
+  my ( $class, $expression, $data, $options ) = @_;
+  return Jmespath::Parser->new->parse( $expression )->search( $data, $options );
+}
+
 sub search {
   my ( $class, $expression, $data, $options ) = @_;
   my ($result);

--- a/t/06_evaluate.t
+++ b/t/06_evaluate.t
@@ -24,3 +24,5 @@ is_deeply(
   Jmespath->evaluate('a', { a => { nested => 'hash' } }),
   { nested => 'hash' }
 );
+
+done_testing;

--- a/t/06_evaluate.t
+++ b/t/06_evaluate.t
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use Jmespath;
+use Test::More;
+
+cmp_ok(
+  Jmespath->evaluate('a', { a => 42 }),
+  '==',
+  42
+);
+
+cmp_ok(
+  Jmespath->evaluate('a', { a => "value" }),
+  'eq',
+  'value'
+);
+
+is_deeply(
+  Jmespath->evaluate('a', { a => [1,2] }),
+  [1,2]
+);
+
+is_deeply(
+  Jmespath->evaluate('a', { a => { nested => 'hash' } }),
+  { nested => 'hash' }
+);


### PR DESCRIPTION
Hi,

  I've added an evaluate function to the Jmespath namespace that doesn't JSONencode the result of matching an expression against a datastructure, returning whatever the expression returned

  In my opinion, search shouldn't JSONencode the result, but I didn't want to break the API

